### PR TITLE
remove NuttX special code

### DIFF
--- a/adb.h
+++ b/adb.h
@@ -18,10 +18,6 @@
 #ifndef __ADB_H
 #define __ADB_H
 
-#ifdef __NUTTX__
-#include <nuttx/config.h>
-#endif
-
 #include <limits.h>
 #include <sys/types.h>
 
@@ -29,10 +25,6 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
-
-#ifndef CONFIG_PATH_MAX
-#define CONFIG_PATH_MAX 256
-#endif
 
 #ifndef UNUSED
 #define UNUSED(x) (void)(x)

--- a/file_sync_service.c
+++ b/file_sync_service.c
@@ -50,7 +50,7 @@
 
 #define min(a,b) ((a) < (b) ? (a):(b))
 
-#define SYNC_TEMP_BUFF_SIZE CONFIG_PATH_MAX
+#define SYNC_TEMP_BUFF_SIZE PATH_MAX
 
 /****************************************************************************
  * Private types
@@ -323,13 +323,13 @@ static int state_init_list(afs_service_t *svc, apacket *p)
     union syncmsg *msg = (union syncmsg*)p->data;
 
     int len = strlen(svc->buff);
-    /* CONFIG_PATH_MAX + "/" + 1 char filename at least + "\x0" => -3 */
-    if (len >= CONFIG_PATH_MAX-3) {
+    /* PATH_MAX + "/" + 1 char filename at least + "\x0" => -3 */
+    if (len >= PATH_MAX-3) {
         adb_log("Dir name too big\n");
         goto exit_done;
     }
 
-    svc->list.path = (char*)malloc(CONFIG_PATH_MAX);
+    svc->list.path = (char*)malloc(PATH_MAX);
     if (svc->list.path == NULL) {
         adb_log("Cannot allocate dirname\n");
         goto exit_done;
@@ -383,7 +383,7 @@ static int state_process_list(afs_service_t *svc, apacket *p)
 
     int len = strlen(de->d_name);
 
-    int remaining = CONFIG_PATH_MAX -
+    int remaining = PATH_MAX -
         (int)(svc->list.file_ptr - svc->list.path);
 
     if (len >= remaining) {
@@ -483,7 +483,7 @@ static int state_init_send_link(afs_service_t *svc, apacket *p)
     int len;
 
     len = strlen(svc->buff);
-    if (len >= CONFIG_PATH_MAX) {
+    if (len >= PATH_MAX) {
         prepare_fail_message(svc, p, "path too long");
         return 0;
     }
@@ -669,7 +669,7 @@ static int state_wait_cmd(afs_service_t *svc, apacket *p)
         return -1;
     }
 
-    if (msg->req.namelen >= CONFIG_PATH_MAX) {
+    if (msg->req.namelen >= PATH_MAX) {
         adb_log("Fail path too big (%d)\n", msg->req.namelen);
         return -1;
     }

--- a/hal/hal_uv.c
+++ b/hal/hal_uv.c
@@ -32,32 +32,21 @@ static adb_context_uv_t g_adbd_context;
 adb_context_t* adb_hal_create_context() {
     adb_context_uv_t *adbd = &g_adbd_context;
 
-#ifdef __NUTTX__
-    uv_library_init(&adbd->uv_context);
-    adbd->loop = uv_default_loop(&adbd->uv_context);
-#else
     adbd->loop = uv_default_loop();
-#endif
 
 #ifdef CONFIG_ADBD_TCP_SERVER
     if (adb_uv_tcp_setup(adbd)) {
-        goto exit_fail;
+        return NULL;
     }
 #endif
 
 #ifdef CONFIG_ADBD_USB_SERVER
     if (adb_uv_usb_setup(adbd, "/dev/adb0")) {
-        goto exit_fail;
+        return NULL;
     }
 #endif
 
     return &adbd->context;
-
-exit_fail:
-#ifdef __NUTTX__
-    uv_library_shutdown(&adbd->uv_context);
-#endif
-    return NULL;
 }
 
 void adb_hal_destroy_context(adb_context_t *context) {

--- a/hal/hal_uv_priv.h
+++ b/hal/hal_uv_priv.h
@@ -46,9 +46,6 @@ typedef struct adb_client_uv_s {
 
 typedef struct adb_context_uv_s {
     adb_context_t context;
-#ifdef __NUTTX__
-    uv_context_t uv_context;
-#endif
     uv_loop_t *loop;
 #ifdef CONFIG_ADBD_TCP_SERVER
     uv_tcp_t tcp_server;


### PR DESCRIPTION
since the new libuv porting for NuttX doesn't need the special process
