### PR TITLE
hal/shell_service_uv.c: add check whether the shell_pipe is active or inactive

### DIFF
--- a/hal/shell_service_uv.c
+++ b/hal/shell_service_uv.c
@@ -196,11 +196,13 @@ static void shell_kick(adb_service_t *service) {
     ash_service_t *svc = container_of(service, ash_service_t, service);
 
     if (!svc->wait_ack) {
-        int ret;
-        ret = uv_read_start((uv_stream_t*)&svc->shell_pipe,
-            alloc_buffer, pipe_on_data_available);
-        /* TODO handle return code */
-        assert(ret == 0);
+        if (!uv_is_active((uv_handle_t*)&svc->shell_pipe)) {
+            int ret;
+            ret = uv_read_start((uv_stream_t*)&svc->shell_pipe,
+                alloc_buffer, pipe_on_data_available);
+            /* TODO handle return code */
+            assert(ret == 0);
+        }
     }
 }
 


### PR DESCRIPTION
When I run adbd in the background, I trigger `adb connect localhost` and `adb shell` in another terminal,
adbd will exit immediately, the error message is as follows:
```
handle_auth_frame (245): skip key verification
handle_auth_frame (267): accept key from mi@mi
adb_register_service (320): id=1, peer=110
adbd: /home/1/microADB/hal/shell_service_uv.c:203: shell_kick: Assertion `ret == 0' failed.
[1]    30723 abort (core dumped)  ./build/adbd
```
When uv_read_start can be executed normally, its return value will always be 0, so maybe we should not use assert to check it.

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>