### PR TITLE
hal: use the uv_err_name(int) function to get information describing the error

### DIFF
--- a/hal/hal_uv_packet.c
+++ b/hal/hal_uv_packet.c
@@ -169,7 +169,8 @@ void adb_uv_on_data_available(adb_client_uv_t *client, uv_stream_t *stream,
     }
     if (nread < 0) {
         if (nread != UV_EOF) {
-            adb_log("read failed %d\n", nread);
+            adb_log("GOT ERROR nread %d, strerror is %s\n", nread,
+                    uv_err_name((int)nread));
         }
         client->client.ops->close(&client->client);
         return;

--- a/hal/hal_uv_socket.c
+++ b/hal/hal_uv_socket.c
@@ -71,6 +71,10 @@ static void tcp_stream_on_data_available(uv_stream_t* handle,
     }
     else {
         /* Notify service an error occured. */
+        if (nread != UV_EOF) {
+            adb_log("GOT ERROR nread %d, strerror is %s\n", nread,
+                    uv_err_name((int)nread));
+        }
         ap->p.msg.data_length = 0;
     }
 

--- a/hal/shell_service_uv.c
+++ b/hal/shell_service_uv.c
@@ -129,7 +129,8 @@ static void pipe_on_data_available(uv_stream_t* stream, ssize_t nread,
 
     if (nread <= 0) {
         if (nread != UV_EOF) {
-            adb_log("GOT ERROR nread %d\n", nread);
+            adb_log("GOT ERROR nread %d, strerror is %s\n", nread,
+                    uv_err_name((int)nread));
         }
         adb_service_close(&client->client, &service->service, p);
         return;


### PR DESCRIPTION
 We can use the `uv_err_name(int)` functions to get a **const char \*** describing the error. Of course, it is also good to replace it with` uv_strerror`. We can clearly know the corresponding error description. 

For specific **Error constants**, please refer to here: [Error constants](https://docs.libuv.org/en/v1.x/errors.html).