### PR TITLE
Fix hal/hal_uv_client_usb.c:154:9: error: implicit declaration of function 'close'

### DIFF
--- a/hal/hal_uv_client_usb.c
+++ b/hal/hal_uv_client_usb.c
@@ -18,6 +18,7 @@
 #include "adb.h"
 #include "hal_uv_priv.h"
 #include <uv.h>
+#include <unistd.h>
 
 /****************************************************************************
  * Private types


### PR DESCRIPTION
Fix the ci error here: https://github.com/apache/nuttx/actions/runs/4100097451/jobs/7070641033