### PR TITLE
adb: adb supports EP device node.

### DIFF
--- a/hal/hal_uv_client_usb.c
+++ b/hal/hal_uv_client_usb.c
@@ -26,7 +26,8 @@
 typedef struct adb_client_usb_s {
     adb_client_uv_t uc;
     /* FIXME libuv handle must be right after adb_client_uv_t */
-    uv_pipe_t pipe;
+    uv_pipe_t read_pipe;
+    uv_pipe_t write_pipe;
 } adb_client_usb_t;
 
 /****************************************************************************
@@ -37,13 +38,13 @@ static void usb_uv_allocate_frame(uv_handle_t* handle,
                        size_t suggested_size, uv_buf_t* buf) {
     UNUSED(suggested_size);
 
-    adb_client_usb_t *client = container_of(handle, adb_client_usb_t, pipe);
+    adb_client_usb_t *client = container_of(handle, adb_client_usb_t, read_pipe);
     adb_uv_allocate_frame(&client->uc, buf);
 }
 
 static void usb_uv_on_data_available(uv_stream_t* handle,
         ssize_t nread, const uv_buf_t* buf) {
-    adb_client_usb_t *client = container_of(handle, adb_client_usb_t, pipe);
+    adb_client_usb_t *client = container_of(handle, adb_client_usb_t, read_pipe);
 
     adb_uv_on_data_available(&client->uc, handle, nread, buf);
 }
@@ -54,6 +55,7 @@ static int usb_uv_write(adb_client_t *c, apacket *p) {
     int buf_cnt;
     apacket_uv_t *up = container_of(p, apacket_uv_t, p);
     adb_client_usb_t *client = container_of(c, adb_client_usb_t, uc.client);
+    uv_stream_t *pipe = (uv_stream_t *)&client->write_pipe;
 
     buf[0].base = (char*)&p->msg;
     buf[0].len  = sizeof(p->msg);
@@ -70,7 +72,8 @@ static int usb_uv_write(adb_client_t *c, apacket *p) {
     /* Packet is now tracked by libuv */
     up->wr.data = &client->uc;
 
-    ret =uv_write(&up->wr, (uv_stream_t*)&client->pipe, buf, buf_cnt,
+
+    ret =uv_write(&up->wr, pipe, buf, buf_cnt,
         adb_uv_after_write);
     if (ret) {
         adb_log("uv_write failed %d %d\n", ret, errno);
@@ -84,9 +87,9 @@ static int usb_uv_write(adb_client_t *c, apacket *p) {
 static void usb_uv_kick(adb_client_t *c) {
     adb_client_usb_t *client = container_of(c, adb_client_usb_t, uc.client);
 
-    if (!uv_is_active((uv_handle_t*)&client->pipe)) {
+    if (!uv_is_active((uv_handle_t*)&client->read_pipe)) {
         /* Restart read events */
-        int ret = uv_read_start((uv_stream_t*)&client->pipe,
+        int ret = uv_read_start((uv_stream_t*)&client->read_pipe,
             usb_uv_allocate_frame,
             usb_uv_on_data_available);
         /* TODO check return code */
@@ -97,7 +100,7 @@ static void usb_uv_kick(adb_client_t *c) {
 }
 
 static void usb_uv_on_close(uv_handle_t* handle) {
-    adb_client_usb_t *client = container_of(handle, adb_client_usb_t, pipe);
+    adb_client_usb_t *client = container_of(handle, adb_client_usb_t, read_pipe);
 
     adb_uv_close_client(&client->uc);
 }
@@ -106,7 +109,8 @@ static void usb_uv_close(adb_client_t *c) {
     adb_client_usb_t *client = (adb_client_usb_t*)c;
 
     /* Close pipe and cancel all pending write requests if any */
-    uv_close((uv_handle_t*)&client->pipe, usb_uv_on_close);
+    uv_close((uv_handle_t*)&client->write_pipe, NULL);
+    uv_close((uv_handle_t*)&client->read_pipe, usb_uv_on_close);
 }
 
 static const adb_client_ops_t adb_usb_uv_ops = {
@@ -120,9 +124,10 @@ static const adb_client_ops_t adb_usb_uv_ops = {
  ****************************************************************************/
 
 int adb_uv_usb_setup(adb_context_uv_t *adbd, const char *path) {
+    char devname[32];
+    adb_client_usb_t *client;
     int ret;
     int fd;
-    adb_client_usb_t *client;
 
     client = (adb_client_usb_t*)adb_uv_create_client(sizeof(*client));
     if (client == NULL) {
@@ -134,28 +139,49 @@ int adb_uv_usb_setup(adb_context_uv_t *adbd, const char *path) {
 
     client->uc.client.ops = &adb_usb_uv_ops;
 
-    ret = uv_pipe_init(adbd->loop, &client->pipe, 0);
-    client->pipe.data = adbd;
+    ret = uv_pipe_init(adbd->loop, &client->read_pipe, 0);
+    client->read_pipe.data = adbd;
     if (ret) {
         adb_log("usb init error %d %d\n", ret, errno);
         return ret;
     }
 
-    fd = open(path, O_RDWR | O_CLOEXEC);
+    snprintf(devname, sizeof(devname), "%s/ep2", path);
+    fd = open(devname, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        adb_err("failed to open usb device %d %d\n", fd, errno);
+        return fd;
+    }
 
+    ret = uv_pipe_open(&client->read_pipe, fd);
+    if (ret) {
+        adb_err("usb pipe open error %d %d\n", ret, errno);
+        close(fd);
+        return ret;
+    }
+
+    ret = uv_pipe_init(adbd->loop, &client->write_pipe, 0);
+    client->write_pipe.data = adbd;
+    if (ret) {
+        adb_err("usb init error %d %d\n", ret, errno);
+        return ret;
+    }
+
+    snprintf(devname, sizeof(devname), "%s/ep1", path);
+    fd = open(devname, O_WRONLY | O_CLOEXEC);
     if (fd < 0) {
         adb_log("failed to open usb device %d %d\n", fd, errno);
         return fd;
     }
 
-    ret = uv_pipe_open(&client->pipe, fd);
+    ret = uv_pipe_open(&client->write_pipe, fd);
     if (ret) {
         adb_log("usb pipe open error %d %d\n", ret, errno);
         close(fd);
         return ret;
     }
 
-    ret = uv_read_start((uv_stream_t*)&client->pipe,
+    ret = uv_read_start((uv_stream_t*)&client->read_pipe,
         usb_uv_allocate_frame,
         usb_uv_on_data_available);
     /* TODO check return code */


### PR DESCRIPTION
Support usb_fs driver so that userspace can directly transfer USB packets through the EP node. microADB device change from /dev/adb0 to /dev/adb0/ep1 and dev/adb0/ep2.