### PR TITLE
fix unused warnings like

### DIFF
--- a/hal/hal_uv_client_usb.c
+++ b/hal/hal_uv_client_usb.c
@@ -95,6 +95,7 @@ static void usb_uv_kick(adb_client_t *c) {
             usb_uv_on_data_available);
         /* TODO check return code */
         assert(ret == 0);
+        UNUSED(ret);
     }
 
     adb_client_kick_services(c);


### PR DESCRIPTION
This is to fix build errors like:
Error: microADB/hal/hal_uv_client_usb.c:90:13: error: unused variable 'ret'
