### PR TITLE
Bug fixes for ADB

### DIFF
--- a/adb_client.c
+++ b/adb_client.c
@@ -409,7 +409,7 @@ void adb_service_close(adb_client_t *client, adb_service_t *svc, apacket *p) {
         goto exit_free_service;
     }
 
-    while (cur_svc->next) {
+    while (cur_svc != NULL && cur_svc->next != NULL) {
         if (cur_svc->next == svc) {
             cur_svc->next = svc->next;
             goto exit_free_service;

--- a/file_sync_service.c
+++ b/file_sync_service.c
@@ -99,6 +99,7 @@ enum {
 typedef struct afs_service_s {
     adb_service_t service;
     uint8_t *packet_ptr;
+    uint8_t *payload;
 
     uint8_t state;
     unsigned cmd;
@@ -260,6 +261,23 @@ static int create_path_directories(char *name)
         }
     }
     return 0;
+}
+
+static uint8_t *get_payload(afs_service_t *svc, apacket *p)
+{
+  if (svc->size > 0) {
+      if (svc->payload == NULL) {
+          svc->payload = malloc(CONFIG_ADBD_PAYLOAD_SIZE);
+          if (svc->payload == NULL) {
+              return NULL;
+          }
+      }
+
+      memcpy(svc->payload, p->data, p->msg.data_length);
+      return svc->payload;
+  }
+
+  return p->data;
 }
 
 static void state_reset(afs_service_t *svc)
@@ -730,7 +748,7 @@ static int state_wait_cmd_data(afs_service_t *svc, apacket *p)
 static int file_sync_on_write(adb_service_t *service, apacket *p) {
     int ret = 0;
     afs_service_t *svc = container_of(service, afs_service_t, service);
-    svc->packet_ptr = p->data;
+    svc->packet_ptr = get_payload(svc, p);
 
     /* Process all packet data */
 
@@ -779,7 +797,7 @@ static int file_sync_on_write(adb_service_t *service, apacket *p) {
 static int file_sync_on_ack(adb_service_t *service, apacket *p) {
     int ret;
     afs_service_t *svc = container_of(service, afs_service_t, service);
-    svc->packet_ptr = p->data;
+    svc->packet_ptr = get_payload(svc, p);
 
     /* No data in notify packet */
     switch (svc->state) {
@@ -791,11 +809,19 @@ static int file_sync_on_ack(adb_service_t *service, apacket *p) {
             ret = state_process_list(svc, p);
             break;
 
+        case AFS_STATE_PROCESS_SEND_FILE_DATA:
         case AFS_STATE_PROCESS_SEND_FILE_HDR:
         case AFS_STATE_PROCESS_SEND_SYM_HDR:
+        case AFS_STATE_WAIT_CMD_DATA:
         case AFS_STATE_WAIT_CMD:
-            /* Nothing to do */
-            ret = 0;
+            /* Since the WRITE frame can contain multiple incomplete
+             * combinations of ID_SEND and ID_DONE, when the pc replies to ID_DONE,
+             * the OKAY frame sent can be at any time in the state machine.
+             * At this time, we should not reset the state machine and continue
+             * to process the next frame status.
+             */
+
+            ret = 1;
             break;
 
         default:
@@ -817,6 +843,7 @@ static int file_sync_on_ack(adb_service_t *service, apacket *p) {
 static void file_sync_on_close(struct adb_service_s *service) {
     afs_service_t *svc = container_of(service, afs_service_t, service);
     state_reset(svc);
+    free(svc->payload);
     free(svc);
 }
 
@@ -842,6 +869,7 @@ adb_service_t* file_sync_service(const char *params)
     }
 
     service->size = 0;
+    service->payload = NULL;
     service->state = AFS_STATE_WAIT_CMD;
     service->service.ops = &file_sync_ops;
 

--- a/hal/hal_uv.c
+++ b/hal/hal_uv.c
@@ -50,7 +50,10 @@ adb_context_t* adb_hal_create_context(void) {
 }
 
 void adb_hal_destroy_context(adb_context_t *context) {
-    UNUSED(context);
+    adb_context_uv_t *adbd =
+        container_of(context, adb_context_uv_t, context);
+
+    uv_loop_close(adbd->loop);
 }
 
 adb_client_t *adb_hal_create_client(size_t size) {

--- a/hal/hal_uv_client_usb.c
+++ b/hal/hal_uv_client_usb.c
@@ -88,6 +88,10 @@ static int usb_uv_write(adb_client_t *c, apacket *p) {
 static void usb_uv_kick(adb_client_t *c) {
     adb_client_usb_t *client = container_of(c, adb_client_usb_t, uc.client);
 
+    if (uv_is_closing((uv_handle_t*)&client->read_pipe)) {
+        return;
+    }
+
     if (!uv_is_active((uv_handle_t*)&client->read_pipe)) {
         /* Restart read events */
         int ret = uv_read_start((uv_stream_t*)&client->read_pipe,

--- a/hal/hal_uv_client_usb.c
+++ b/hal/hal_uv_client_usb.c
@@ -111,8 +111,8 @@ static void usb_uv_close(adb_client_t *c) {
     adb_client_usb_t *client = (adb_client_usb_t*)c;
 
     /* Close pipe and cancel all pending write requests if any */
-    uv_close((uv_handle_t*)&client->write_pipe, NULL);
     uv_close((uv_handle_t*)&client->read_pipe, usb_uv_on_close);
+    uv_close((uv_handle_t*)&client->write_pipe, NULL);
 }
 
 static const adb_client_ops_t adb_usb_uv_ops = {

--- a/hal/shell_service_uv.c
+++ b/hal/shell_service_uv.c
@@ -89,7 +89,9 @@ static int shell_set_cloexec(int fd) {
 static void on_child_exit(uv_process_t *process, int64_t exit_status,
         int term_signal) {
     ash_service_t *svc = (ash_service_t*)process->data;
+    adb_client_uv_t *client = (adb_client_uv_t *)svc->shell_pipe.data;
 
+    adb_service_close(&client->client, &svc->service, NULL);
     adb_log("shell %d<->%d exited with status %ld, signal %d\n",
         svc->service.id, svc->service.peer_id,
         exit_status, term_signal);

--- a/hal/shell_service_uv.c
+++ b/hal/shell_service_uv.c
@@ -221,8 +221,6 @@ static void shell_close(adb_service_t *service) {
 
   /* Terminate child process in case it is still running */
 
-  uv_process_kill(&svc->process, SIGKILL);
-
   uv_close((uv_handle_t *)&svc->shell_pipe, shell_close_pipe_callback);
 }
 


### PR DESCRIPTION
# Summary
1. Fix used after free issue about handle close - 243f21e2ec8081e26131357a590bed45a783013b
2. Fix memory leaks when adbd exit - 6b47b63c14d4bcef45df1ecb7265a93109fbf56c
3. Call service_close to send CLSE frame when child task exit - 262457c25b7cd465181904bf5444e97dd6737596
4. Avoid kick when read/write pipe had beed close - 25236f019e1e932b16f48535fdb56f7d2eb5c13b
5. Send response before adb_reboot_impl() to avoid host reporting error log - e70f524e218439cde3820afdfb80d61d653c1836
6. Check whether client has services before close to fix crash - 84f46c05f401dec658b226ae6d66195de4850a9e
7. Copy packet to svc to prevent the current packet from being overwritten - 868a51c21e40d5fc166678b598c71ce3a189cb29
8. Avoid sending termination signals to tasks that are accessing the file system to avoid deadlock - 0e3390d8e13120199d7b34fbf95cd335ac350aab

# Impact
Bugfix for microADB.
# Test
- Selftest
- CI