### PR TITLE
Skip environment variables when exec logcat

### DIFF
--- a/adb_client.c
+++ b/adb_client.c
@@ -371,7 +371,7 @@ static adb_service_t *adb_service_open(adb_client_t *client, const char *name, a
             /* Search for logcat */
             char *ptr = strstr(name, "exec logcat");
             if (ptr) {
-                svc = logcat_service(client, name);
+                svc = logcat_service(client, ptr);
                 break;
             }
 #endif /* CONFIG_ADBD_LOGCAT_SERVICE */


### PR DESCRIPTION
# Summary
Log
```
$ adb -s emulator-5554 logcat
nsh: export: command not found
```
Packet
```
  0000   00 00 00 00 00 00 00 00 00 00 00 00 08 00 45 00   ..............E.
  0010   00 64 44 d7 40 00 40 06 f7 ba 7f 00 00 01 7f 00   .dD.@.@.........
  0020   00 01 d6 05 15 b3 5f a7 fe 39 f6 e2 f8 80 80 18   ......_..9......
  0030   02 00 fe 58 00 00 01 01 08 0a 29 24 9c b4 29 24   ...X......)$..)$
  0040   9c b4 73 68 65 6c 6c 3a 65 78 70 6f 72 74 20 41   ..shell:export A
  0050   4e 44 52 4f 49 44 5f 4c 4f 47 5f 54 41 47 53 3d   NDROID_LOG_TAGS=
  0060   22 27 27 22 3b 20 65 78 65 63 20 6c 6f 67 63 61   "''"; exec logca
  0070   74 00                                             t.
```
# Impact
adb logcat
# Testing
- Selftest as above
- CI